### PR TITLE
Various small fixes to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,10 +1,13 @@
 * SSH2 SFTP Client
 
-an SFTP client for node.js, a wrapper around [[https://github.com/mscdex/ssh2][SSH2]]  which provides a high level
-convenience abstraction as well as a Promise based API.
+an SFTP client for node.js, a wrapper around
+[[https://github.com/mscdex/ssh2][SSH2]] which provides a high level convenience
+abstraction as well as a Promise-based API.
 
 Documentation on the methods and available options in the underlying modules can
-be found on the [[https://github.com/mscdex/ssh2][SSH2]] and [[https://github.com/mscdex/ssh2-streams/blob/master/SFTPStream.md][SSH2-STREAMS]]  project pages.
+be found on the [[https://github.com/mscdex/ssh2][SSH2]] and
+[[https://github.com/mscdex/ssh2-streams/blob/master/SFTPStream.md][SSH2-STREAMS]]
+project pages.
 
 Current stable release is *v4.3.1*.
 
@@ -92,7 +95,8 @@ There has been minor changes to the API signatures
 * Documentation
 
 The connection options are the same as those offered by the underlying SSH2
-module. For full details, please see [[https://github.com/mscdex/ssh2#user-content-client-methods][SSH2 client methods]]
+module. For full details, please see
+[[https://github.com/mscdex/ssh2#user-content-client-methods][SSH2 client methods]]
 
 All the methods will return a Promise, except for ~on()~ and
 ~removeListener()~, which are typically only used in special use cases.
@@ -174,7 +178,8 @@ client has thrown the error.
       return sftp.end();
     })
     .catch(err => {
-      console.log(`Error: ${err.message}`); // error message will include 'example-client'
+      console.log(`Error: ${err.message}`); // error message will include
+                                            // 'example-client'
     });
 #+end_src
 
@@ -185,16 +190,18 @@ available [[https://github.com/mscdex/ssh2#user-content-client-methods][here]]
 
 **** Connection Options
 
-This module is based on the excellent [[https://github.com/mscdex/ssh2#client][SSH2]] module. That module is a general SSH2
-client and server library and provides much more functionality than just SFTP
-connectivity. Many of the connect options provided by that module are less
+This module is based on the excellent
+[[https://github.com/mscdex/ssh2#client][SSH2]] module. That module is a general
+SSH2 client and server library and provides much more functionality than just
+SFTP connectivity. Many of the connect options provided by that module are less
 relevant for SFTP connections. It is recommended you keep the config options to
 the minimum needed and stick to the options listed in the ~commonOpts~ below.
 
 The ~retries~, ~retry_factor~ and ~retry_minTimeout~ options are not part of the
-SSH2 module. These are part of the configuration for the [[https://www.npmjs.com/package/retry][retry]] package and what
-is used to enable retrying of sftp connection attempts. See the documentation
-for that package for an explanation of these values.
+SSH2 module. These are part of the configuration for the
+[[https://www.npmjs.com/package/retry][retry]] package and what is used to
+enable retrying of sftp connection attempts. See the documentation for that
+package for an explanation of these values.
 
 #+begin_src javascript
   // common options
@@ -207,7 +214,8 @@ for that package for an explanation of these values.
     username: 'donald', // string Username for authentication.
     password: 'borsch', // string Password for password-based user authentication
     agent: process.env.SSH_AGENT, // string - Path to ssh-agent's UNIX socket
-    privateKey: fs.readFileSync('/path/to/key'), // Buffer or string that contains
+    privateKey: fs.readFileSync('/path/to/key'), // Buffer or string that
+                                                 // contains the key data
     passphrase; 'a pass phrase', // string - For an encrypted private key
     readyTimeout: 20000, // integer How long (in ms) to wait for the SSH handshake
     strictVendor: true // boolean - Performs a strict server vendor check
@@ -256,9 +264,9 @@ realised, returns an array of objects representing items in the remote
 directory.
 
 - path :: {String} Remote directory path
-- pattern :: (optional) {string|RegExp} A pattern used to filter the items included in the returned
-             array. Pattern can be a simple /glob/-style string or a regular
-             expression. Defaults to ~/.*/~.
+- pattern :: (optional) {string|RegExp} A pattern used to filter the items
+             included in the returned array. Pattern can be a simple
+             /glob/-style string or a regular expression. Defaults to ~/.*/~.
 
 **** Example Use
 
@@ -486,8 +494,8 @@ throughput. This is the simplest method if you just want to download a file.
   {
     concurrency: 64, // integer. Number of concurrent reads to use
     chunkSize: 32768, // integer. Size of each read in bytes
-    step: function(total_transferred, chunk, total) // callback called each time a
-                                                    // chunk is transferred
+    step: function(total_transferred, chunk, total) // callback called each time
+                                                    // a chunk is transferred
   }
 #+end_src
 
@@ -570,7 +578,8 @@ often result in data corruption.
 *** fastPut(localPath, remotePath, options) ==> string
 
 Uploads the data in file at ~localPath~ to a new file on remote server at
-~remotePath~ using concurrency. The options object allows tweaking of the fast put process.
+~remotePath~ using concurrency. The options object allows tweaking of the fast
+put process.
 
 - localPath :: string. Path to local file to upload
 - remotePath :: string. Path to remote file to create
@@ -583,8 +592,9 @@ Uploads the data in file at ~localPath~ to a new file on remote server at
     concurrency: 64, // integer. Number of concurrent reads
     chunkSize: 32768, // integer. Size of each read in bytes
     mode: 0o755, // mixed. Integer or string representing the file mode to set
-    step: function(total_transferred, chunk, total) // function. Called every time
-    // a part of a file was transferred
+    step: function(total_transferred, chunk, total) // function. Called every
+                                                    // time a part of a file was
+                                                    // transferred
   }
 #+end_src
 
@@ -1090,14 +1100,15 @@ issue.
    - Fix connection retry feature
    - sftp connection object set to null when 'end' signal is raised
    - Removed 'connectMethod' argument from connect method.
-   - Refined adding/removing of listeners in connect() and end() methods to enable
-     errors to be adequately caught and reported.
+   - Refined adding/removing of listeners in connect() and end() methods to
+     enable errors to be adequately caught and reported.
    - Deprecate auxList() and add pattern/regexp filter option to list()
    - Refactored handling of event signals to provide better feedback to clients
    - Removed pointless 'permissions' property from objects returned by ~stat()~
      (same as mode property). Added additional properties describing the type of
      object.
-   - Added the ~removeListener()~ method to compliment the existing ~on()~ method.
+   - Added the ~removeListener()~ method to compliment the existing ~on()~
+     method.
 
 ** v2.5.2
    - Repository transferred to theophilusx
@@ -1140,14 +1151,20 @@ issue.
   - fix: get readable not emitting data events in node 10.0.0
 
 ** v2.1.1
-   - add: event listener. [[https://github.com/jyu213/ssh2-sftp-client#Event][doc]]
-   - add: ~get~ or ~put~ method add extra options [[https://github.com/jyu213/ssh2-sftp-client/pull/52][pr#52]]
+   - add: event listener.
+     [[https://github.com/jyu213/ssh2-sftp-client#Event][doc]]
+   - add: ~get~ or ~put~ method add extra options
+     [[https://github.com/jyu213/ssh2-sftp-client/pull/52][pr#52]]
 
 ** v2.0.1
-   - add: ~chmod~ method [[https://github.com/jyu213/ssh2-sftp-client/pull/33][pr#33]]
-   - update: upgrade ssh2 to V0.5.0 [[https://github.com/jyu213/ssh2-sftp-client/pull/30][pr#30]]
-   - fix: get method stream error reject unwork [[https://github.com/jyu213/ssh2-sftp-client/issues/22][#22]]
-   - fix: return Error object on promise rejection [[https://github.com/jyu213/ssh2-sftp-client/pull/20][pr#20]]
+   - add: ~chmod~ method
+     [[https://github.com/jyu213/ssh2-sftp-client/pull/33][pr#33]]
+   - update: upgrade ssh2 to V0.5.0
+     [[https://github.com/jyu213/ssh2-sftp-client/pull/30][pr#30]]
+   - fix: get method stream error reject unwork
+     [[https://github.com/jyu213/ssh2-sftp-client/issues/22][#22]]
+   - fix: return Error object on promise rejection
+     [[https://github.com/jyu213/ssh2-sftp-client/pull/20][pr#20]]
 
 ** v1.1.0
    - fix: add encoding control support for binary stream

--- a/README.org
+++ b/README.org
@@ -110,12 +110,12 @@ considered to be relative to whatever the remote server considers to be the
 configured, this may not always be what you expect. The module also does some
 very basic tests on results returned from the remote server to try and determine
 platform type and will replace path separators with whatever the remote systems
-uses (e.g. replace ~/~ with ~\~ on MS Windows). 
+uses (e.g. replace ~/~ with ~\~ on MS Windows).
 
 There is a small performance hit for using ~./~ and ~../~ as the module must
 query the remote server to determine what the root path is and derive the
 absolute path. Using absolute paths are therefore more efficient and likely more
-robust. 
+robust.
 
 When specifying file paths, ensure to include a full path i.e. include the
 remote filename. Don't expect the module to append the local file name to the
@@ -220,7 +220,7 @@ package for an explanation of these values.
     readyTimeout: 20000, // integer How long (in ms) to wait for the SSH handshake
     strictVendor: true // boolean - Performs a strict server vendor check
     debug: myDebug // function - Set this to a function that receives a single
-                  // string argument to get detailed (local) debug information.
+                   // string argument to get detailed (local) debug information.
     retries: 2 // integer. Number of times to retry connecting
     retry_factor: 2 // integer. Time factor used to calculate time between retries
     retry_minTimeout: 2000 // integer. Minimum timeout between attempts
@@ -357,7 +357,7 @@ if it exists or false if it does not.
       return sftp.exists('/path/to/remote/dir');
     })
     .then(data => {
-      console.log(data);          // will be false or d, -, l (dir, file or link)
+      console.log(data); // will be false or d, -, l (dir, file or link)
     })
     .then(() => {
       sftp.end();
@@ -1016,7 +1016,7 @@ This solution was provided by @jmorino.
   // client is connected
 #+end_src
 
-** Timeout while waiting for handshake or handshake errors 
+** Timeout while waiting for handshake or handshake errors
 
 Some users have encountered the error 'Timeout while waiting for handshake' or
 'Handshake failed, no matching client->server ciphers. This is often due to the
@@ -1026,7 +1026,7 @@ used by ssh2. One of the connect options provided by the ssh2 module is
 exchange, ciphers, hmac and compression algorithms as well as server
 host key used to establish the initial secure connection. See the SSH2
 documentation for details. Getting these parameters correct usually resolves the
-issue. 
+issue.
 
 * Change Log
 ** v4.3.1 (Prod Version)
@@ -1034,23 +1034,23 @@ issue.
    - Added errorListener to error event in each promise to catch error events
      and reject the promise. This should resolve the issue of some error events
      causing uncaughtException erros and causing the process to exit.
- 
+
 ** v4.3.0 (Prod Version)
    - Ensure errors include an err.code property and pass through the error code
      from the originating error
    - Change tests for error type to use ~error.code~ instead of matching on
      ~error.message~.
 
-** v4.2.4 
+** v4.2.4
    - Bumped ssh2 to v0.8.6
    - Added exists() usage example to examples directory
    - Clarify documentation on get() method
-** v4.2.3 
+** v4.2.3
    - Fix bug in ~exist()~ where tests on root directory returned false
    - Minor documentation fixes
    - Clean up mkdir example
 
-** v4.2.2 
+** v4.2.2
    - Minor documentation fixes
    - Added additional examples in the ~example~ directory
 
@@ -1173,7 +1173,7 @@ issue.
    - fix: multi image upload
    - change: remove ~this.client.sftp~ to ~connect~ function
 
-* Troubleshooting 
+* Troubleshooting
 
 The ~ssh2-sftp-client~ module is essentially a wrapper around the ~ssh2~ and
 ~ssh2-streams~ modules, providing a higher level ~promise~ based API. When you
@@ -1184,7 +1184,7 @@ reproducible example which reproduces the issue. Once you have that, try to
 replicate the functionality just using the ~ssh2~ and ~ssh2-streams~ modules. If
 the issue still occurs, then you can be fairly confident it is something related
 to those later 2 modules and therefore and issue which should be referred to the
-maintainer of that module. 
+maintainer of that module.
 
 The ~ssh2~ and ~ssh2-streams~ modules are very solid, high quality modules with
 a large user base. Most of the time, issues with those modules are due to client
@@ -1194,7 +1194,7 @@ these modules have good defaults, the flexibility of the ssh2 protocol means
 that not all options are available by default. You may need to tweak the
 connection options, ssh2 algorithms and ciphers etc for some remote servers. The
 documentation for both the ~ssh2~ and ~ssh2-streams~ module is quite
-comprehensive and there is lots of valuable information in the issue logs. 
+comprehensive and there is lots of valuable information in the issue logs.
 
 If you run into an issue which is not repeatable with just the ~ssh2~ and
 ~ssh2-streams~ modules, then please log an issue against the ~ssh2-sftp-client~
@@ -1203,14 +1203,14 @@ module and I will investigate. Please note the next section on logging issues.
 Note also that in the repository there are two useful directories. The first is
 the examples directory, which contain some examples of using ~ssh2-sftp-client~
 to perform common tasks. A few minutes reviewing these examples can provide that
-additional bit of detail to help fix any problems you are encountering. 
+additional bit of detail to help fix any problems you are encountering.
 
 The second directory is the tools directory. I have some very basic simple
 scripts in this directory which perform basic tasks using only the ~ssh2~ and
 ~ssh2-streams~ modules (no ssh2-sftp-client module). These can be useful when
 trying to determine if the issue is with the underlying ~ssh2~ and
-~ssh2-streams~ modules. 
- 
+~ssh2-streams~ modules.
+
 * Logging Issues
 
 Please log an issue for all bugs, questions, feature and enhancement
@@ -1228,11 +1228,11 @@ the issue. Things which will help
 - Platform and software for the remote SFTP server when possible
 - Example of your code. By far, the most common issue is incorrect use of the
   module API. Example code can usually result in such issues being resolved very
-  quickly. 
+  quickly.
 
 Perhaps the best assistance is a minimal reproducible example of the issue. Once
-the issue can be readily reproduced, it can usually be fixed very quickly. 
- 
+the issue can be readily reproduced, it can usually be fixed very quickly.
+
 * Pull Requests
 
 Pull requests are always welcomed. However, please ensure your changes pass all

--- a/README.org
+++ b/README.org
@@ -207,20 +207,20 @@ package for an explanation of these values.
   // common options
 
   let commonOpts {
-    host: 'localhost', // string Hostname or IP of server.
-    port: 22, // Port number of the server.
+    host: 'localhost', // string Hostname or IP of server
+    port: 22, // port number of the server
     forceIPv4: false, // boolean (optional) Only connect via IPv4 address
     forceIPv6: false, // boolean (optional) Only connect via IPv6 address
-    username: 'donald', // string Username for authentication.
+    username: 'donald', // string Username for authentication
     password: 'borsch', // string Password for password-based user authentication
     agent: process.env.SSH_AGENT, // string - Path to ssh-agent's UNIX socket
-    privateKey: fs.readFileSync('/path/to/key'), // Buffer or string that
+    privateKey: fs.readFileSync('/path/to/key'), // buffer or string that
                                                  // contains the key data
     passphrase; 'a pass phrase', // string - For an encrypted private key
     readyTimeout: 20000, // integer How long (in ms) to wait for the SSH handshake
     strictVendor: true // boolean - Performs a strict server vendor check
     debug: myDebug // function - Set this to a function that receives a single
-                   // string argument to get detailed (local) debug information.
+                   // string argument to get detailed (local) debug information
     retries: 2 // integer. Number of times to retry connecting
     retry_factor: 2 // integer. Time factor used to calculate time between retries
     retry_minTimeout: 2000 // integer. Minimum timeout between attempts
@@ -383,7 +383,7 @@ The ~stat()~ method returns an object with the following properties;
     uid: 1000, // user ID
     gid: 985, // group ID
     size: 5, // file size
-    accessTime: 1566868566000, // Last access time. milliseconds
+    accessTime: 1566868566000, // last access time. milliseconds
     modifyTime: 1566868566000, // last modify time. milliseconds
     isDirectory: false, // true if object is a directory
     isFile: true, // true if object is a file
@@ -902,7 +902,7 @@ bring them across before saving to local file system.
 
   // Example of using a writeable with get to retrieve a file.
   // This code will read the remote file, convert all characters to upper case
-  // and then save it to a local file
+  // and then save it to a local file.
 
   const Client = require('../src/index.js');
   const path = require('path');


### PR DESCRIPTION
- Adjust long lines to conform to the existing 80-character wrap
- Fix whitespace issues (spaces at EOL and incorrect indentation)
- Adjust punctuation and capitalization in comments to be uniform across the file