### PR TITLE
Moved Mocha back to DevDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "concat-stream": "^2.0.0",
-    "mocha": "^8.0.1",
     "retry": "^0.12.0",
     "ssh2": "^0.8.9",
     "through2": "^4.0.2"
@@ -33,6 +32,7 @@
     "chai-subset": "^1.6.0",
     "checksum": "^0.1.1",
     "dotenv": "^8.2.0",
+    "mocha": "^8.0.1",
     "moment": "^2.27.0"
   }
 }


### PR DESCRIPTION
Node Version: v12.16.1
Library Version: 5.1.3 (Issue does not repro with 5.1.2)
Platform: macOS

It appears that during a recent dependencies bump Mocha was converted to a Dependency from a Dev Dependency. 

[Link to the File & Commit](https://github.com/theophilusx/ssh2-sftp-client/commit/bd07187ad4319d246ec4ab31c1016a62423d74f8#diff-b9cfc7f2cdf78a7f4b91a753d10865a2).

I discovered this because I have an application leveraging this library. I recently updated the version of the library I was using and ran into issues with Yarn performing upgrades in our mono repo. My specific issue is not really a huge deal, I am able to rollback library versions and still run.

However, I figured I would point out the issue and open a PR because it appears the change from DevDependency to Dependency was unintentional.