### PR TITLE
docs: Fix a readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1836,7 +1836,7 @@ following will not do what you expect
       });
 
 In the above code, the `sftp.end()` method will almost certainly be called
-before `sftp.gastGet()` has been fulfilled (unless the *foo.txt* file is
+before `sftp.fastGet()` has been fulfilled (unless the *foo.txt* file is
 really small!). In fact, the whole promise chain will complete and exit even
 before the `sftp.end()` call has been fulfilled. The correct code would be
 something like

--- a/README.org
+++ b/README.org
@@ -1655,7 +1655,7 @@ trying to determine if the issue is with the underlying ~ssh2~ and
     #+end_src
 
     In the above code, the ~sftp.end()~ method will almost certainly be called
-    before ~sftp.gastGet()~ has been fulfilled (unless the /foo.txt/ file is
+    before ~sftp.fastGet()~ has been fulfilled (unless the /foo.txt/ file is
     really small!). In fact, the whole promise chain will complete and exit even
     before the ~sftp.end()~ call has been fulfilled. The correct code would be
     something like


### PR DESCRIPTION
Fixes a small readme typo. sftp.gastGet() -> sftp.fastGet()