### PR TITLE
[bug fix] Corrects typo in `put` method to ensure options args are used if set (when `localSrc` string)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -716,7 +716,7 @@ class SftpClient {
             this.debugMsg(`put source is a file path: ${localSrc}`);
             rdr = fs.createReadStream(
               localSrc,
-              options.readStreamOptions ? options.readStreamOptons : {}
+              options.readStreamOptions ? options.readStreamOptions : {}
             );
           } else {
             this.debugMsg('put source is a stream');


### PR DESCRIPTION
If a user calls the `put` method with options that include `readStreamOptions` _and_ the `localSrc` is a string, the `readStreamOptions` options are not currently being used due to a typo.

-  fixes typo