### PR TITLE
Fix connect() not returning the sftp channel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,7 @@ class SftpClient {
           minTimeout: config.retry_minTimeout || 1000,
         }
       );
-      await this.getSftpChannel();
+      return this.getSftpChannel();
     } catch (err) {
       this.debugMsg(`connect: Error ${err.message}`);
       this._resetEventFlags();

--- a/test/01connections.js
+++ b/test/01connections.js
@@ -39,7 +39,8 @@ describe('Connect Tests', function () {
 
   it('contest-2: valid connection object', async function () {
     let client = new Client('contest-2');
-    await client.connect(config);
+    const sftpChannel = await client.connect(config);
+    expect(sftpChannel).to.equal(client.sftp);
     let type = typeof client.sftp;
     await client.end();
     return expect(type).to.equal('object');


### PR DESCRIPTION
Fixes #353, a regression from 7.0.1, and adds a test to verify this for future versions.