### PR TITLE
fix: Resolve PUT method on Writable 'close' instead of 'finish'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -704,7 +704,7 @@ class SftpClient {
           this.debugMsg(`put: write stream error ${err.message}`);
           reject(fmtError(`${err.message} ${remotePath}`, 'put', err.code));
         });
-        wtr.once('finish', () => {
+        wtr.once('close', () => {
           this.debugMsg('put: promise resolved');
           resolve(`Uploaded data stream to ${remotePath}`);
         });


### PR DESCRIPTION
This fixes the issue #355 by resolving the promise after the write stream emits `close` instead of `finish`.