### PR TITLE
unlink, not rm

### DIFF
--- a/test/19utils.js
+++ b/test/19utils.js
@@ -260,7 +260,7 @@ describe('localExists tests', function () {
   });
 
   after('cleanup', function () {
-    fs.rmSync(`${config.localUrl}/test-file1-link.txt`);
+    fs.unlinkSync(`${config.localUrl}/test-file1-link.txt`);
   });
 
   it('file exists', function () {


### PR DESCRIPTION
...... because we created a symbolic file before