### PR TITLE
Resolve promise immediately in get method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -528,6 +528,17 @@ class SftpClient {
                 resolve(wtr);
               }
             });
+          } else if (
+            Object.hasOwnProperty.call(options, 'pipeOptions') &&
+            Object.hasOwnProperty.call(options.pipeOptions, 'immediately') &&
+            !options.pipeOptions.immediately
+          ) {
+            this.debugMsg('get resolved immediately');
+            if (typeof dst === 'string') {
+              resolve(dst);
+            } else {
+              resolve(wtr);
+            }
           } else {
             wtr.once('finish', () => {
               this.debugMsg('get resolved on writer finish event');


### PR DESCRIPTION
## First of all I want say thanks for you work!!!

## Env
Node version: 16-alpine
Version of ssh2-sftp-client: "7.2.1"
Platform your client is running on: Unix
Platform and software for the remote SFTP server: Unix

## Problem:
I try to download big file file for example 5 Gb and I faced with 500 response from Nginx during waiting. 
It can not wait longer than 60 sec, and I can bump into memory limitation.

## My understanding of the problem
In current implementation of `get` method we must wait for whole file will be read to `rdr` stream and only after `rdr.on('end',...`/rdr.on('finish',...` event we resolve promise with returned stream.

## Solution propose 
If we will not wait for `rdr` which will emit end/finish event but immediately return it as is.
And farther handling will be delegated to client code which call it.

What do you think about it?

Thanks.