### PR TITLE
Updated removeTempListeners to clear the specific tempListeners array

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -148,7 +148,7 @@ function removeTempListeners(obj, name) {
     obj.tempListeners[name].forEach(([e, fn]) => {
       obj.client.removeListener(e, fn);
     });
-    obj.tempListeners = [];
+    obj.tempListeners[name] = [];
   }
 }
 


### PR DESCRIPTION
Clearing the `obj.tempListeners` and setting it from an `object` to an `array` gives me the following error when trying to read a file to a write stream using the 'get' command:
```
 TypeError: obj.tempListeners[name].forEach is not a function
    at removeTempListeners (/home/new/node_modules/ssh2-sftp-client/src/utils.js:148:29)
    at /home/new/node_modules/ssh2-sftp-client/src/index.js:545:7
    at <anonymous>
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

I think you ment to clear the array of events of a key in the 'tempListeners' object, not the entire object itself. This small change fixes the error for me and allowed me to succesfully download the file from the SFTP server.