### PR TITLE
recursive filter in downloadDir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1353,7 +1353,7 @@ class SftpClient {
       for (const d of dirDownloads) {
         let src = `${srcDir}/${d.name}`;
         let dst = join(dstDir, d.name);
-        await this.downloadDir(src, dst);
+        await this.downloadDir(src, dst, options);
       }
       return `${srcDir} downloaded to ${dstDir}`;
     } catch (err) {


### PR DESCRIPTION
Hi. Thanks for your work!

I found that with downloadDir filter and useFastGET options isn't propagated to recursive calls.