### PR TITLE
Add Limit to Concurrent Promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "concat-stream": "^2.0.0",
+    "p-limit": "3.1.0",
     "promise-retry": "^2.0.1",
     "ssh2": "^1.12.0"
   }


### PR DESCRIPTION
I've attempted to fix the issues here (#481 #490) by limiting the number of concurrent promises that can occur at a given time, using the [p-limit](https://www.npmjs.com/package/p-limit) package.

I've come accross these issues myself where it seems files are being skipped and not uploaded due to resource limits being reached with too many Node listeners being added etc. Hopefully this will help fix the problem.

I've also added the option for the user to specify the concurrency limit in the `Client()` constructor, however, a better approach may be to include this in the connection method options. I'll leave this decision up to the maintainer.