### PR TITLE
fix vulnerability CVE-2023-48795, updated ssh2 package version to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   "dependencies": {
     "concat-stream": "^2.0.0",
     "promise-retry": "^2.0.1",
-    "ssh2": "^1.14.0"
+    "ssh2": "^1.15.0"
   }
 }


### PR DESCRIPTION
this PR only updates the target version in package.json for ssh2 from 1.14.0 to 1.15.0 to fix vulnerability CVE-2023-48795.

The tests require a .env file / dir that I do not have, so I am not able to test it, but hoping the original repo has devops that will verify update is compatible with code base.

More Info on CVE-2023-48795:
A [CVE advisory for a medium severity issue](https://github.com/advisories/GHSA-45x7-px36-x8w8) is reported in the latest release version, 1.14.0

Original report link: https://www.cve.org/CVERecord?id=CVE-2023-48795

**Impact:**
This rolls up to wrappers for Node.js including this project. An application I am working on which is flagging in our dependency vulnerability scanning system, potentially leading to the need to move to a new package implementation if no fix is issued. 

**More Info:**
The SSH transport protocol with certain OpenSSH extensions, found in OpenSSH before 9.6 and other products, allows remote attackers to bypass integrity checks such that some packets are omitted (from the extension negotiation message), and a client and server may consequently end up with a connection for which some security features have been downgraded or disabled, aka a Terrapin attack. This occurs because the SSH Binary Packet Protocol (BPP), implemented by these extensions, mishandles the handshake phase and mishandles use of sequence numbers. 

For example, there is an effective attack against SSH's use of ChaCha20-Poly1305 (and CBC with Encrypt-then-MAC). The bypass occurs in [chacha20-poly1305@openssh.com](mailto:chacha20-poly1305@openssh.com) and (if CBC is used) the [-etm@openssh.com](mailto:-etm@openssh.com) MAC algorithms. This also affects Maverick Synergy Java SSH API before 3.1.0-SNAPSHOT, Dropbear through 2022.83, Ssh before 5.1.1 in Erlang/OTP, PuTTY before 0.80, AsyncSSH before 2.14.2, golang.org/x/crypto before 0.17.0, libssh before 0.10.6, libssh2 through 1.11.0, Thorn Tech SFTP Gateway before 3.4.6, Tera Term before 5.1, Paramiko before 3.4.0, jsch before 0.2.15, SFTPGo before 2.5.6, Netgate pfSense Plus through 23.09.1, Netgate pfSense CE through 2.7.2, HPN-SSH through 18.2.0, ProFTPD before 1.3.8b (and before1.3.9rc2), ORYX CycloneSSH before 2.3.4, NetSarang XShell 7 before Build 0144, CrushFTP before 10.6.0, ConnectBot SSH library before 2.2.22, Apache MINA sshd through 2.11.0, sshj through 0.37.0, TinySSH through 20230101, trilead-ssh2 6401, the net-ssh gem 7.2.0 for Ruby, the mscdex ssh2 module before 1.15.0 for Node.js, the thrussh library before 0.35.1 for Rust, and the Russh crate before 0.40.2 for Rust; and there could be effects on Bitvise SSH through 9.31.


**Vulnerable Library** - ssh2-1.14.0.tgz
**Base Score Metrics:**

    Exploitability Metrics:
        Attack Vector: Network
        Attack Complexity: High
        Privileges Required: None
        User Interaction: None
        Scope: Unchanged
    Impact Metrics:
        Confidentiality Impact: None
        Integrity Impact: High
        Availability Impact: None
        
