### PR TITLE
docs(README.org): downloadDir explicit work on content

### DIFF
--- a/README.org
+++ b/README.org
@@ -989,7 +989,7 @@ remote SFTP server will result in failures.
 
 *** downloadDir(srcDir, dstDir, options) ==> string
 
-Download the remote directory specified by ~srcDir~ to the local file system
+Download the content of the remote directory specified by ~srcDir~ to the local file system
 directory specified by ~dstDir~. The ~dstDir~ directory will be created if
 required. All sub directories within ~srcDir~ will also be copied. Any existing
 files in the local path will be overwritten. No files in the local path will be


### PR DESCRIPTION
Explicitly describe that `downloadDir` will download the **content** of `srcDir`, and not `srcDir` itself.

https://github.com/theophilusx/ssh2-sftp-client/blob/v10.0.3/src/index.js#L1383

IIUC, `README.md` is generated from `README.org`, so I modified the latter only. https://github.com/theophilusx/ssh2-sftp-client?tab=readme-ov-file#pull-requests