### PR TITLE
Add types for `Client.stat` function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,28 @@
+type Stats = {
+  /** Integer representing type and permissions */
+  mode: string;
+  /** User ID */
+  uid: number;
+  /** Group ID */
+  gid: number;
+  /** File size */
+  size: number;
+  /** Last access time in milliseconds */
+  accessTime: number;
+  /** Last modify time in milliseconds */
+  modifyTime: number;
+  /** True if the object is a directory */
+  isDirectory: boolean;
+  /** True if the object is a file */
+  isFile: boolean;
+  /** True if the object is a block device */
+  isBlockDevice: boolean;
+  /** True if the object is a character device */
+  isCharacterDevice: boolean;
+  /** True if the object is a symbolic link */
+  isSymbolicLink: boolean;
+  /** True if the object is a FIFO */
+  isFIFO: boolean;
+  /** True if the object is a socket */
+  isSocket: boolean;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -287,7 +287,7 @@ class SftpClient {
    * @param {Function} cmd - either this.sftp.stat or this.sftp.lstat
    * @param {String} remotePath - a string containing the path to a file
    * @param {Boolean} addListeners - (Optional) if true add event listeners. Default true.
-   * @return {Promise<Object>} stats - attributes info
+   * @return {Promise<Stats>} stats - attributes info
    */
   _xstat(cmd, aPath, addListeners = true) {
     let listeners;
@@ -333,7 +333,7 @@ class SftpClient {
     });
   }
 
-  /*
+  /**
    * Use the stat command to obtain attributes associated with a remote path.
    * THe difference between stat and lstat is that stat, in the case of symbolic
    * links, will return the attributes associated with the target of the link. With
@@ -341,7 +341,7 @@ class SftpClient {
    * returned.
    *
    * @param {String} remotePath - path to an object on the remote server
-   * @return {Promise<Object>} stats - attributes info
+   * @return {Promise<Stats>} stats - attributes info
    */
   async stat(remotePath) {
     try {
@@ -352,7 +352,7 @@ class SftpClient {
     }
   }
 
-  /*
+  /**
    * Use the lstat command to obtain attributes associated with a remote path.
    * THe difference between stat and lstat is that stat, in the case of symbolic
    * links, will return the attributes associated with the target of the link. With
@@ -360,7 +360,7 @@ class SftpClient {
    * returned.
    *
    * @param {String} remotePath - path to an object on the remote server
-   * @return {Promise<Object>} stats - attributes info
+   * @return {Promise<Stats>} stats - attributes info
    */
   async lstat(remotePath) {
     try {


### PR DESCRIPTION
I am not sure why the `Client.stat` function returned only an object when there is a object with a defined structure in it. I added a `Stats` type so it could be used : ) The comments are just copy and paste from the npm page. 