### PR TITLE
fix: added RST-on-END handling

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,11 @@ function errorListener(client, name, reject) {
       client.debugMsg(`${name} errorListener - ignoring handled error ${err.message}`);
       return;
     }
+    // ignore ECONNRESET if end() has been called, as we can be confident that a reset connection is definitely dead
+    if (client.endCalled && err.code === 'ECONNRESET') {
+      client.debugMsg(`${name} errorListener - ignoring ${err.message} on end`);
+      return;
+    }
     client.debugMsg(`${name} errorListener - handling error ${err.message}`);
     client.errorHandled = true;
     const newError = new Error(`${name}: ${err.message}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,7 +65,7 @@ function errorListener(client, name, reject) {
       return;
     }
     // ignore ECONNRESET if end() has been called, as we can be confident that a reset connection is definitely dead
-    if (client.endCalled && err.code === 'ECONNRESET') {
+    if (name === 'end' && client.endCalled && err.code === 'ECONNRESET') {
       client.debugMsg(`${name} errorListener - ignoring ${err.message} on end`);
       return;
     }

--- a/test/27rst-on-end.js
+++ b/test/27rst-on-end.js
@@ -1,0 +1,80 @@
+const { Server } = require('ssh2');
+const chai = require('chai');
+const expect = chai.expect;
+const chaiAsPromised = require('chai-as-promised');
+const chaiSubset = require('chai-subset');
+const { getConnection } = require('./hooks/global-hooks.js');
+chai.use(chaiAsPromised);
+chai.use(chaiSubset);
+
+let server;
+describe('27rstOnEnd: end() method tests', function () {
+  let sftp;
+
+  before('setup mock SSH server', function (done) {
+    server = new Server({
+      hostKeys: [`-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACAEUC8mxihJM03nlm2KlueNMGf2EZ0R6pWrc28R/+OE3AAAAKBSF4SmUheE
+pgAAAAtzc2gtZWQyNTUxOQAAACAEUC8mxihJM03nlm2KlueNMGf2EZ0R6pWrc28R/+OE3A
+AAAED8hNH6eiXiiQX6An4mKKR0iOw1UyqWPoDszao6btWoewRQLybGKEkzTeeWbYqW540w
+Z/YRnRHqlatzbxH/44TcAAAAFnJoeXN3aWxsaWFtc0BNYWMubG9jYWwBAgMEBQYH
+-----END OPENSSH PRIVATE KEY-----`],
+    }, (client) => {
+      // Force the socket to use resetAndDestroy on end() to trigger ECONNRESET for testing
+      const socket = client._sock;
+      socket.end = function(...args) {
+        if (socket.resetAndDestroy) {
+          socket.resetAndDestroy();
+        }
+      };
+
+      client.on('authentication', (ctx) => {
+        ctx.accept();
+      });
+
+      client.on('ready', () => {
+        client.on('session', (accept, reject) => {
+          const session = accept();
+          session.on('sftp', (accept, reject) => {
+            const sftp = accept();
+            sftp.on('REALPATH', (reqId, path) => {
+              const resultPath = path === '.' ? '/' : path;
+              sftp.name(reqId, [{ filename: resultPath }]);
+            });
+            sftp.on('STAT', (reqId, path) => {
+              sftp.attrs(reqId, { mode: 0o755, size: 0, uid: 1000, gid: 1000 });
+            });
+          });
+        });
+      });
+    });
+
+    server.listen(2222, '0.0.0.0', () => {
+      console.log('SFTP Mock Server started on port 2222');
+      done();
+    });
+  })
+
+  before('list() test setup hook', async function () {
+    sftp = await getConnection({
+      username: "mock",
+      password: "mock",
+      host: "localhost",
+      port: 2222,
+    });
+    sftp.on("debug", (msg) => {console.log(msg);});
+    return true;
+  });
+
+  it('end should not throw an exception on RST', async function () {
+    await expect(sftp.end()).to.be.fulfilled;
+  });
+
+  after('destroy mock SSH server', function (done) {
+    server.close(() => {
+      console.log('SFTP Mock Server destroyed');
+      done();
+    })
+  })
+});

--- a/test/27rst-on-end.js
+++ b/test/27rst-on-end.js
@@ -3,7 +3,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const chaiAsPromised = require('chai-as-promised');
 const chaiSubset = require('chai-subset');
-const { getConnection } = require('./hooks/global-hooks.js');
+const { getConnection, logger } = require('./hooks/global-hooks.js');
 chai.use(chaiAsPromised);
 chai.use(chaiSubset);
 
@@ -51,7 +51,7 @@ Z/YRnRHqlatzbxH/44TcAAAAFnJoeXN3aWxsaWFtc0BNYWMubG9jYWwBAgMEBQYH
     });
 
     server.listen(2222, '0.0.0.0', () => {
-      console.log('SFTP Mock Server started on port 2222');
+      logger.debug('SFTP Mock Server started on port 2222');
       done();
     });
   })
@@ -73,7 +73,7 @@ Z/YRnRHqlatzbxH/44TcAAAAFnJoeXN3aWxsaWFtc0BNYWMubG9jYWwBAgMEBQYH
 
   after('destroy mock SSH server', function (done) {
     server.close(() => {
-      console.log('SFTP Mock Server destroyed');
+      logger.debug('SFTP Mock Server destroyed');
       done();
     })
   })

--- a/test/hooks/global-hooks.js
+++ b/test/hooks/global-hooks.js
@@ -38,7 +38,7 @@ const config = {
   host: process.env.SFTP_SERVER,
   username: process.env.SFTP_USER,
   password: process.env.SFTP_PASSWORD,
-  privateKey: readFileSync(process.env.SFTP_KEY_FILE),
+  privateKey: process.env.SFTP_KEY_FILE ? readFileSync(process.env.SFTP_KEY_FILE) : null,
   passphrase: process.env.SFTP_KEY_PASSPHRASE,
   port: process.env.SFTP_PORT || 22,
   localUrl: process.env.LOCAL_URL,
@@ -84,9 +84,9 @@ const lastRemoteDir = (p) => {
 
 let con;
 
-async function getConnection() {
+async function getConnection(configOverride = {}) {
   try {
-    let baseConfig = { ...config };
+    let baseConfig = { ...config, ...configOverride };
     delete baseConfig.privateKey;
     delete baseConfig.passphrase;
     if (!con) {

--- a/test/hooks/global-hooks.js
+++ b/test/hooks/global-hooks.js
@@ -146,4 +146,5 @@ module.exports = {
   lastRemoteDir,
   getConnection,
   closeConnection,
+  logger
 };


### PR DESCRIPTION
Proposed fix for https://github.com/theophilusx/ssh2-sftp-client/issues/589

Ultimately, this fix is located in a fairly ubiquitous listener. I know a concern was about potentially leaving idle connections behind; however, I don't believe we should run into a scenario where a RST connection remains open. 

In all cases, a RST packet immediately and forcibly terminates the TCP connection. The OS network stack will tear down the connection regardless, and thus, I feel it's safe to assume that we can handle it as a successfully terminated connection and ignore the error.

Let me know if you'd prefer that I make this conditional on the ident presented by the server, though I worry that it may be quite clunky to implement.